### PR TITLE
Update serviceWorker.ts

### DIFF
--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -29,7 +29,7 @@ export function register(config?: Config) {
   if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
     // The URL constructor is available in all browsers that support SW.
     const publicUrl = new URL(
-      process.env.PUBLIC_URL,
+      process.env.PUBLIC_URL!,
       window.location.href
     );
     if (publicUrl.origin !== window.location.origin) {


### PR DESCRIPTION
fixed error: "Argument of type 'string'  | 'undefined' is not assignable to parameter of type 'string'  | 'URL'